### PR TITLE
修复account长度为12时，无法登陆的问题

### DIFF
--- a/packages/jm-user/lib/service/index.js
+++ b/packages/jm-user/lib/service/index.js
@@ -269,7 +269,7 @@ class Service {
       query.push({
         email: username
       })
-    } else if (bson.ObjectId.isValid(username)) {
+    } else if (bson.ObjectId.isValid(username) && username.length===24) {
       query.push({
         _id: username
       })


### PR DESCRIPTION
调整原因：
1. 兼容历史版本
2. 由于objectid源代码中的isValid函数会兼容24位的16进制字符串和12字节的字符串。但是目前这个user服务使用id登陆时，不会用到12位的字节。此外，bson官方源码中，也会根据字符串位数(12/24)不同，做不同的处理
https://github.com/mongodb/js-bson/blob/master/lib/objectid.js